### PR TITLE
Feature flag for `log` crate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: 'rust'
 
 rust:
-  - 'stable'
-  - 'beta'
-  - 'nightly'
 
 matrix:
   fast_finish: true
 
+  include:
+  - rust: 'nightly'
+  - rust: 'beta'
+  - rust: 'stable'
+
   allow_failures:
-    - rust: 'nightly'
+  - rust: 'nightly'
+
+script:
+  - 'cargo check'
+  - 'cargo clean'
+  - 'cargo check --no-default-features'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.1
+
+* Add: Feature flag for `log` crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ license = "MIT"
 
 edition = "2018"
 
+[features]
+# disable logging by disabling log feature
+default = ["log"]
+
 [dependencies]
 crossbeam-channel = "0.3"
 hyper = "0.12"
-log = "0.4"
-
-[dependencies.prometheus]
-version = "0.7"
-default-features = false
+log = { version = "0.4", optional = true }
+prometheus = { version = "0.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus_exporter"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Alexander Thaller <alexander.thaller@trivago.com>"]
 
 description = "Helper libary to export prometheus metrics using hyper."
@@ -11,6 +11,12 @@ repository = "https://github.com/AlexanderThaller/prometheus_exporter"
 license = "MIT"
 
 edition = "2018"
+
+[badges]
+travis-ci = { repository = "AlexanderThaller/prometheus_exporter" }
+
+[package.metadata.docs.rs]
+features = ["log"]
 
 [features]
 # disable logging by disabling log feature

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use hyper::{
     Response,
     Server,
 };
+#[cfg(feature = "log")]
 use log::{
     error,
     info,
@@ -91,9 +92,9 @@ impl PrometheusExporter {
 
         let server = Server::try_bind(&addr)?
             .serve(service)
-            .map_err(|e| error!("problem while serving metrics: {}", e));
+            .map_err(log_serving_error);
 
-        info!("Listening on http://{}", addr);
+        log_startup(&addr);
 
         rt::run(server);
 
@@ -127,9 +128,9 @@ impl PrometheusExporter {
 
             let server = Server::bind(&addr)
                 .serve(service)
-                .map_err(|e| error!("problem while serving metrics: {}", e));
+                .map_err(log_serving_error);
 
-            info!("Listening on http://{}", addr);
+            log_startup(&addr);
 
             rt::run(server);
         });
@@ -159,9 +160,9 @@ impl PrometheusExporter {
 
             let server = Server::bind(&addr)
                 .serve(service)
-                .map_err(|e| error!("problem while serving metrics: {}", e));
+                .map_err(log_serving_error);
 
-            info!("Listening on http://{}", addr);
+            log_startup(&addr);
 
             rt::run(server);
         });
@@ -193,4 +194,16 @@ impl PrometheusExporter {
             .body(Body::from(message))
             .unwrap()
     }
+}
+
+#[allow(unused)]
+fn log_startup(addr: &SocketAddr) {
+    #[cfg(feature = "log")]
+    info!("Listening on http://{}", addr);
+}
+
+#[allow(unused)]
+fn log_serving_error(error: HyperError) {
+    #[cfg(feature = "log")]
+    error!("problem while serving metrics: {}", error)
 }


### PR DESCRIPTION
This adds a feature flag for the log crate.
This makes it possible to disable logging via a Cargo.toml feature flag.

* Disables the dependency on the log crate.
* Disables startup info log line.
* Disables hyper error logging.