### PR TITLE
update tiny_http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
 prometheus = { version = "0.11", default-features = false }
 thiserror = "1"
-tiny_http = { version = "0.7", default-features = false }
+tiny_http = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.8"


### PR DESCRIPTION
This PR updates to TinyHTTP 0.8

Not sure what else the changelog includes, but I'd like this because it supresses `Broken Pipe` Errors so that they are not surfaced to the caller as per https://github.com/tiny-http/tiny-http/pull/192