### PR TITLE
Switch tiny_http version to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
 prometheus = { version = "0.13", default-features = false }
 thiserror = "1"
-tiny_http = { version = "0.9", default-features = false }
+tiny_http = { version = "0.10.0", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
 prometheus = { version = "0.13", default-features = false }
 thiserror = "1"
-tiny_http = { version = "0.10.0", default-features = false }
+tiny_http = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus_exporter"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Alexander Thaller <alexander.thaller@trivago.com>"]
 
 description = "Helper libary to export prometheus metrics using tiny-http."


### PR DESCRIPTION
reason:
`cargo audit` fails on tiny_http 
```
Scanning Cargo.lock for vulnerabilities (243 crate dependencies)
Crate:         chrono
Version:       0.4.19
Title:         Potential segfault in `localtime_r` invocations
Date:          2020-11-10
ID:            RUSTSEC-2020-0159
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0159
Solution:      No safe upgrade is available!
Dependency tree: 
chrono 0.4.19
└── tiny_http 0.9.0
```
`tiny_http 0.10.0` changelog:

`chrono` replaced with `time-rs`
>chrono was only used to store and format DateTime into the slightly odd format required by RFC 7231, so to avoid the numerous RUSTSEC advisories generated by the localtime_r issue, we can just drop it entirely and switch to time-rs. Unfortunately this means we need to bump our minimum tested compiler version to 1.51, and as such this change requires a full minor release.