### PR TITLE
Allow using a custom registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/AlexanderThaller/prometheus_exporter"
 
-edition = "2018"
+edition = "2021"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 features = ["logging", "internal_metrics"]

--- a/examples/custom_registry.rs
+++ b/examples/custom_registry.rs
@@ -1,0 +1,47 @@
+// Will create an exporter with a single metric that does not change
+// using a custom registry instead of the global one
+
+use env_logger::{
+    Builder,
+    Env,
+};
+use log::info;
+use prometheus_exporter::prometheus::{
+    register_gauge_with_registry,
+    Registry,
+};
+use std::net::SocketAddr;
+
+fn main() {
+    // Setup logger with default level info so we can see the messages from
+    // prometheus_exporter.
+    Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    // Parse address used to bind exporter to.
+    let addr_raw = "0.0.0.0:9184";
+    let addr: SocketAddr = addr_raw.parse().expect("can not parse listen addr");
+
+    // Setup a registry
+    let registry = Registry::new_custom(Some("my_prefix".to_string()), None)
+        .expect("Failed to create registry");
+
+    // Create metric
+    let metric = register_gauge_with_registry!("simple_the_answer", "to everything", registry)
+        .expect("can not create gauge simple_the_answer");
+
+    metric.set(42.0);
+
+    let mut builder = prometheus_exporter::Builder::new(addr);
+    builder.with_registry(registry);
+
+    // Start exporter
+    builder.start().expect("can not start exporter");
+
+    // Get metrics from exporter
+    let body = reqwest::blocking::get(&format!("http://{}/metrics", addr_raw))
+        .expect("can not get metrics from exporter")
+        .text()
+        .expect("can not body text from request");
+
+    info!("Exporter metrics:\n{}", body);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,8 @@
 //!   bytes.
 //! * `prometheus_exporter_request_duration_seconds`: The HTTP request latencies
 //!   in seconds.
+//!
+//! This feature will not work in combination with using a custom registry.
 
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
@@ -293,7 +295,8 @@ impl Builder {
 
     /// Sets the registry the metrics will be gathered from. If the registry is
     /// not set, the default registry provided by the prometheus crate will be
-    /// used.
+    /// used. If a custom registry is used, the metrics provided by the
+    /// `internal_metrics` feature are not available.
     pub fn with_registry(&mut self, registry: prometheus::Registry) {
         self.registry = registry;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,7 @@ enum HandlerError {
 pub struct Builder {
     binding: SocketAddr,
     endpoint: Endpoint,
+    registry: prometheus::Registry,
 }
 
 #[derive(Debug)]
@@ -270,6 +271,7 @@ impl Builder {
         Self {
             binding,
             endpoint: Endpoint::default(),
+            registry: prometheus::default_registry().clone(),
         }
     }
 
@@ -287,6 +289,13 @@ impl Builder {
         clean_endpoint.push_str(endpoint.trim_matches('/'));
         self.endpoint = Endpoint(clean_endpoint);
         Ok(())
+    }
+
+    /// Sets the registry the metrics will be gathered from. If the registry is
+    /// not set, the default registry provided by the prometheus crate will be
+    /// used.
+    pub fn with_registry(&mut self, registry: prometheus::Registry) {
+        self.registry = registry;
     }
 
     /// Create and start new exporter based on the information from the builder.
@@ -311,6 +320,7 @@ impl Builder {
             request_sender,
             is_waiting,
             update_lock,
+            self.registry,
         )?;
 
         Ok(exporter)
@@ -368,6 +378,7 @@ impl Server {
         request_sender: SyncSender<Arc<Barrier>>,
         is_waiting: Arc<AtomicBool>,
         update_lock: Arc<Mutex<()>>,
+        registry: prometheus::Registry,
     ) -> Result<(), Error> {
         let server = HTTPServer::http(&binding).map_err(Error::ServerStart)?;
 
@@ -385,6 +396,7 @@ impl Server {
                         &request_sender,
                         &is_waiting,
                         &update_lock,
+                        registry.clone(),
                     )
                 } else {
                     Self::handler_redirect(request, &endpoint)
@@ -408,6 +420,7 @@ impl Server {
         request_sender: &SyncSender<Arc<Barrier>>,
         is_waiting: &Arc<AtomicBool>,
         update_lock: &Arc<Mutex<()>>,
+        registry: prometheus::Registry,
     ) -> Result<(), HandlerError> {
         #[cfg(feature = "internal_metrics")]
         HTTP_COUNTER.inc();
@@ -432,11 +445,15 @@ impl Server {
         #[cfg(feature = "internal_metrics")]
         drop(timer);
 
-        Self::process_request(request, encoder)
+        Self::process_request(request, encoder, registry)
     }
 
-    fn process_request(request: Request, encoder: &TextEncoder) -> Result<(), HandlerError> {
-        let metric_families = prometheus::gather();
+    fn process_request(
+        request: Request,
+        encoder: &TextEncoder,
+        registry: prometheus::Registry,
+    ) -> Result<(), HandlerError> {
+        let metric_families = registry.gather();
         let mut buffer = vec![];
 
         encoder


### PR DESCRIPTION
Greets!
first of all, awesome work! This lib is my favorite way (across multiple languages, but especially in Rust) to write exporters. Just does exactly what i want.

One nice to have, would be #14 . My use case is to configure an application prefix, which is currently only possible by 'manually' adding it to every metric.
So, I started working on this and wanted to get some feedback. This implementation should work without braking any API. But, the currently global request metrics from the `internal_metrics` feature won't show up, as those are registered with the default registry, of course.

One solution is, to move those, maybe combined with the registry, as private fields inside the server struct. We could then reference it in   `handler_metrics` and `process_request`, initializing the internal metrics in the `Server::start`.
Another one would be to use a new struct, just for passing this "bunch of metrics related things" around.

What do you think?