### PR TITLE
Add missing Content-Type header

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,13 +42,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set rust version
-        run: rustup override set 1.62
+        run: rustup override set 1.83
 
       - name: Run tests
-        run: cargo +1.62 test --verbose
+        run: cargo +1.83 test --verbose
 
       - name: Run tests with default features disabled
-        run: cargo +1.62 test --no-default-features --verbose
+        run: cargo +1.83 test --no-default-features --verbose
 
   build:
     runs-on: ubuntu-latest
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set rust version
-        run: rustup override set 1.62
+        run: rustup override set 1.83
 
       - name: Build
-        run: cargo +1.62 build --verbose
+        run: cargo +1.83 build --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,7 +717,16 @@ impl Server {
         #[cfg(feature = "internal_metrics")]
         internal_metrics.http_body_gauge.set(buffer.len() as i64);
 
-        let response = Response::from_data(buffer).with_status_code(status_code);
+        let response = Response::from_data(buffer)
+            .with_status_code(status_code)
+            .with_header(Header {
+                field: "Content-Type"
+                    .parse()
+                    .expect("can not parse content-type header field. this should never fail"),
+                value: "text/plain; charset=UTF-8"
+                    .parse()
+                    .expect("can not parse header value. this should never fail"),
+            });
         request.respond(response).map_err(HandlerError::Response)?;
 
         Ok(())


### PR DESCRIPTION
Fixes #44, the `Response::from_data` function does not set any headers when creating the response, so the `Content-Type` header has to be added manually.